### PR TITLE
Add mkpath before put data

### DIFF
--- a/PageBute/PageBute.pl
+++ b/PageBute/PageBute.pl
@@ -581,8 +581,8 @@ sub _page_bute {
                 $ctx->stash('FirstContents', $output);
                 $ctx->stash('FirstFileName', $file);
             } else {
-                            $fmgr->put_data($output,"${file}.new");
-                            $fmgr->rename("${file}.new",$file);
+                            defined($fmgr->put_data($output,"${file}.new")) or warn $fmgr->errstr;
+                            defined($fmgr->rename("${file}.new",$file)) or warn $fmgr->errstr;
                         }
 
             $output_page_contents = '';
@@ -613,8 +613,8 @@ sub _repage_bute {
 
     my $blog = $ctx->stash('blog');
     my $fmgr = $blog->file_mgr;
-    $fmgr->put_data($contents,"${file}.new");
-    $fmgr->rename("${file}.new",$file);
+    defined($fmgr->put_data($contents,"${file}.new")) or warn $fmgr->errstr;
+    defined($fmgr->rename("${file}.new",$file)) or warn $fmgr->errstr;
 
     $ctx->stash('FirstFileName',0);
 }

--- a/PageBute/PageBute.pl
+++ b/PageBute/PageBute.pl
@@ -581,6 +581,11 @@ sub _page_bute {
                 $ctx->stash('FirstContents', $output);
                 $ctx->stash('FirstFileName', $file);
             } else {
+                            my $path = dirname($file);
+                            $path =~ s/\/$// unless $path eq '/';
+                            unless($fmgr->exists($path)) {
+                                defined($fmgr->mkpath($path)) or warn $fmgr->errstr;
+                            }
                             defined($fmgr->put_data($output,"${file}.new")) or warn $fmgr->errstr;
                             defined($fmgr->rename("${file}.new",$file)) or warn $fmgr->errstr;
                         }


### PR DESCRIPTION
HTMLファイルを出力する前にmkpathでディレクトリを作成していないため、プレビューなどを行っていなければ出力先ディレクトリが存在せずに2ページ目以降の生成に失敗する場合がある問題を修正。
